### PR TITLE
Scipy linkage matrix is always of type float64

### DIFF
--- a/higra/interop/py_scipy.cpp
+++ b/higra/interop/py_scipy.cpp
@@ -22,7 +22,7 @@ namespace py = pybind11;
 
 using namespace hg;
 
-template<typename tree_t, typename T1, typename T2, typename value_t=typename T1::value_type>
+template<typename tree_t, typename T1, typename T2, typename value_t=double>
 auto binary_hierarchy_to_scipy_linkage_matrix(const tree_t &tree,
                                               const xt::xexpression<T1> &xaltitudes,
                                               const xt::xexpression<T2> &xarea) {
@@ -110,7 +110,7 @@ void py_init_scipy(pybind11::module &m) {
             (m,
              "Converts an Higra binary hierarchy to a SciPy linkage matrix."
             );
-    add_type_overloads<def_scipy_linkage_matrix_to_binary_hierarchy, HG_TEMPLATE_FLOAT_TYPES>
+    add_type_overloads<def_scipy_linkage_matrix_to_binary_hierarchy, double>
             (m,
              "Converts a SciPy linkage matrix to an Higra binary hierarchy."
             );

--- a/test/python/test_interop/test_interop_scipy.py
+++ b/test/python/test_interop/test_interop_scipy.py
@@ -17,12 +17,14 @@ class TestSciPyInterop(unittest.TestCase):
 
     def test_binary_hierarchy_to_scipy_linkage_matrix(self):
         t = hg.Tree((5, 5, 7, 6, 6, 7, 8, 8, 8))
-        ref = np.asarray(((0, 1, 1 / 3, 2),
-                          (3, 4, 2 / 3, 2),
-                          (2, 5, 2 / 3, 3),
-                          (6, 7, 1, 5)))
-        res = hg.binary_hierarchy_to_scipy_linkage_matrix(t)
+        altitudes = np.asarray((0, 0, 0, 0, 0, 1, 2, 2, 3), dtype=np.int32)
+        ref = np.asarray(((0, 1, 1, 2),
+                          (3, 4, 2, 2),
+                          (2, 5, 2, 3),
+                          (6, 7, 3, 5)))
+        res = hg.binary_hierarchy_to_scipy_linkage_matrix(t, altitudes=altitudes)
         self.assertTrue(np.allclose(ref, res))
+        self.assertTrue(res.dtype == np.float64)
 
     def test_scipy_linkage_matrix_to_binary_hierarchy(self):
         linkage_matrix = np.asarray(((0, 1, 1, 2),


### PR DESCRIPTION
Solves https://github.com/PerretB/Higra/issues/35