### PR TITLE
Fix bug in assess horizontal cut

### DIFF
--- a/higra/assessment/fragmentation_curve.py
+++ b/higra/assessment/fragmentation_curve.py
@@ -9,7 +9,7 @@
 ############################################################################
 
 import higra as hg
-
+import numpy as np
 
 @hg.argument_helper(hg.CptHierarchy, ("leaf_graph", hg.CptRegionAdjacencyGraph))
 def make_assesser_fragmentation_optimal_cut(tree,
@@ -89,6 +89,10 @@ def assess_fragmentation_horizontal_cut(altitudes,
     :param vertex_map: optional, vertex mapping if the hierarchy is build on a region adjacency graph (deduced from :class:`~higra.CptRegionAdjacencyGraph` on the leaf graph of `tree`)
     :return: an object of type :class:`~higra.FragmentationCurve`
     """
+
+    if ground_truth.dtype != np.int64:
+        ground_truth = ground_truth.astype(np.int64)
+
     if vertex_map is None:
         return hg.cpp._assess_fragmentation_horizontal_cut(tree, altitudes, ground_truth, measure,
                                                            max_regions=max_regions)

--- a/include/higra/algo/horizontal_cuts.hpp
+++ b/include/higra/algo/horizontal_cuts.hpp
@@ -136,13 +136,12 @@ namespace hg {
         inline
         auto horizontal_cut_from_index(index_t cut_index) {
             auto num_regions = m_num_regions_cuts[cut_index];
-            array_1d<index_t> nodes = xt::empty<index_t>({(size_t) num_regions});
+            array_1d<index_t> nodes = array_1d<index_t>::from_shape({(size_t) num_regions});
             if (cut_index == 0) { // special case for single region partition
                 nodes(0) = root(m_tree);
             } else {
                 auto altitude = m_altitudes_cuts[cut_index];
                 auto &range = m_range_nodes_cuts[cut_index];
-
                 for (index_t i = range.first, j = 0; i <= range.second; i++) {
                     for (auto c: children_iterator(i, m_tree)) {
                         if (m_altitudes(c) <= altitude) {

--- a/include/higra/assessment/fragmentation_curve.hpp
+++ b/include/higra/assessment/fragmentation_curve.hpp
@@ -65,7 +65,7 @@ namespace hg {
         }
 
         auto num_regions_normalized() const {
-            return xt::eval(m_num_regions / (value_t)m_num_regions_ground_truth);
+            return xt::eval(m_num_regions / (value_t) m_num_regions_ground_truth);
         }
 
     private:
@@ -105,7 +105,7 @@ namespace hg {
                 }
             } else { // tree on rag
                 hg_assert(vertex_map.size() == ground_truth.size(), "Vertex map and ground truth sizes do not match.");
-                for (index_t i = 0; i < (index_t)vertex_map.size(); i++) {
+                for (index_t i = 0; i < (index_t) vertex_map.size(); i++) {
                     card_intersection_leaves(vertex_map(i), ground_truth(i))++;
                 }
             }
@@ -163,11 +163,11 @@ namespace hg {
 
 // TODO remove when xtensor MSVC witht he bug with xt::view(region_tree_area, xt::all(), xt::newaxis()) on 1d tensor
 #ifndef _MSC_VER
-			array_1d<index_t> region_tree_area;
+            array_1d<index_t> region_tree_area;
 #else
-			array_nd<index_t> region_tree_area;
+            array_nd<index_t> region_tree_area;
 #endif
-            
+
             // for a tree node i, a gt region j: card_intersection(i, j) is the number of pixels in R_i cap R_j
             array_2d<index_t> card_intersection_leaves{{num_leaves(tree), region_gt_areas.size()}, 0};
             if (vertex_map.size() <= 1) { // no rag
@@ -178,7 +178,7 @@ namespace hg {
                 region_tree_area = attribute_area(tree);
             } else { // tree on rag
                 hg_assert(vertex_map.size() == ground_truth.size(), "Vertex map and ground truth sizes do not match.");
-                for (index_t i = 0; i < (index_t)vertex_map.size(); i++) {
+                for (index_t i = 0; i < (index_t) vertex_map.size(); i++) {
                     card_intersection_leaves(vertex_map(i), ground_truth(i))++;
                 }
                 region_tree_area = attribute_area(tree,
@@ -188,7 +188,7 @@ namespace hg {
 
             array_2d<double> card_intersection = accumulate_sequential(tree, card_intersection_leaves,
                                                                        accumulator_sum());
-			
+
             array_1d<double> scores;
 
             switch (measure) {
@@ -209,7 +209,7 @@ namespace hg {
                     break;
             }
 
-            // initialize scoring for single region partitions (hte node itself)
+            // initialize scoring for single region partitions (the node itself)
             for (auto i: leaves_to_root_iterator(tree)) {
                 backtracking.push_back({{1, scores(i), 0, 0}});
             }
@@ -254,7 +254,7 @@ namespace hg {
         auto fragmentation_curve() const {
             auto &backtrack_root = backtracking[root(m_tree)];
             array_1d<double> final_scores({backtrack_root.size()}, 0);
-            for (index_t i = 0; i < (index_t)backtrack_root.size(); i++) {
+            for (index_t i = 0; i < (index_t) backtrack_root.size(); i++) {
                 final_scores(i) = backtrack_root[i].score;
             }
 
@@ -358,7 +358,7 @@ namespace hg {
                 }
             };
 
-            for (index_t i = 1; i < (index_t)backtrack_root.size(); i++) {
+            for (index_t i = 1; i < (index_t) backtrack_root.size(); i++) {
                 double score = backtrack_root[i].score;
                 double previous_score = backtrack_root[i - 1].score;
                 double score_gain = score - previous_score;
@@ -406,9 +406,10 @@ namespace hg {
         auto last_cut = std::upper_bound(num_regions_cuts.begin(), num_regions_cuts.end(), max_regions);
 
         index_t num_cuts = std::distance(num_regions_cuts.begin(), last_cut);
+
         array_1d<double> scores = xt::empty<double>({num_cuts});
-        array_1d<double> num_regions = xt::empty<double>({num_cuts});
-        std::copy(num_regions_cuts.begin(), num_regions_cuts.end(), num_regions.begin());
+        array_1d<index_t> num_regions = xt::empty<index_t>({num_cuts});
+        std::copy(num_regions_cuts.begin(), num_regions_cuts.begin() + num_cuts, num_regions.begin());
 
         for (index_t i = 0; i < num_cuts; i++) {
             auto hc = hc_explorer.horizontal_cut_from_index(i);

--- a/test/cpp/assessment/test_fragmentation_curve.cpp
+++ b/test/cpp/assessment/test_fragmentation_curve.cpp
@@ -211,5 +211,4 @@ namespace assessment_fragmentation_curve {
             REQUIRE(xt::allclose(res_scores, ref_scores / 11));
             REQUIRE(res_k == ref_k);
     }
-
 }

--- a/test/python/test_assessment/test_fragmentation_curve.py
+++ b/test/python/test_assessment/test_fragmentation_curve.py
@@ -88,7 +88,7 @@ class TestFragmentationCurve(unittest.TestCase):
         tree = hg.Tree((11, 11, 11, 12, 12, 16, 13, 13, 13, 14, 14, 17, 16, 15, 15, 18, 17, 18, 18))
 
         altitudes = np.asarray((0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 3, 1, 2, 3))
-        ground_truth = np.asarray((0, 0, 0, 0, 1, 1, 1, 2, 2, 2, 2), dtype=np.int64)
+        ground_truth = np.asarray((0, 0, 0, 0, 1, 1, 1, 2, 2, 2, 2), dtype=np.int16)
 
         res = hg.assess_fragmentation_horizontal_cut(altitudes,
                                                      ground_truth,


### PR DESCRIPTION
Using max_regions lower than the number of horizontal cut in the hierarchy was producing a write at invalid location